### PR TITLE
Add hasUnmodestImage and isPotentiallyDangerous parameters

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -235,3 +235,51 @@ Both modes block all outbound Internet traffic; the distinction is mainly about 
 * Pick **`OFFLINE`** for apps that work perfectly without any network so you avoid showing an unnecessary notification.
 
 ---
+
+### ⚠️ Optional Flags: Content and Risk Warnings
+
+You can optionally include the following boolean flags in your policy files to help with sensitive app filtering and user awareness:
+
+* **`hasUnmodestImage`**: Set to `true` if the app contains unfiltered, inappropriate or immodest visual content (e.g. uncovered women in media banners, icons, or previews). This indicates that the user must explicitly accept the risk in order to use the app.
+
+* **`isPotentiallyDangerous`**: Set to `true` if the app can pose a technical or security risk, such as remote access tools or apps capable of controlling other devices over open internet connections. This flag helps apply stricter rules or prompt additional warnings.
+
+These fields are optional but enforced by default: apps with these flags will not appear in the store or be granted internet access unless the user has explicitly accepted the associated risk.
+
+Apps marked with either of these flags will only appear in the store or receive internet access **if the user has explicitly acknowledged the risk** and chosen to enable them manually.
+
+---
+
+### 🔄 Example: Risky Applications
+
+#### 1. Bank App with Inappropriate Visuals
+
+```json
+{
+  "type": "Fixed",
+  "packageName": "com.example.fakebank",
+  "category": "FINANCE",
+  "minimumVersionCode": 100,
+  "hasUnmodestImage": true,
+  "networkPolicy": {
+    "mode": "FULL_OPEN"
+  }
+}
+```
+
+#### 2. Remote Access Tool
+
+```json
+{
+  "type": "Fixed",
+  "packageName": "com.example.remotecontrol",
+  "category": "TOOLS",
+  "minimumVersionCode": 50,
+  "isPotentiallyDangerous": true,
+  "networkPolicy": {
+    "mode": "FULL_OPEN"
+  }
+}
+```
+
+Both of these apps are tagged for additional caution. They will only be functional or visible if the user has agreed to unlock them by accepting the risks.

--- a/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/AppPolicy.kt
+++ b/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/AppPolicy.kt
@@ -11,6 +11,7 @@ sealed interface AppPolicy {
     val minimumVersionCode: Int
 
     val hasUnmodestImage : Boolean
+    val isPotentiallyDangerous : Boolean
     val detectionRules: List<DetectionRule>
 }
 

--- a/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/AppPolicy.kt
+++ b/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/AppPolicy.kt
@@ -9,6 +9,8 @@ sealed interface AppPolicy {
     val packageName: String
     val category: AppCategory
     val minimumVersionCode: Int
+
+    val hasUnmodestImage : Boolean
     val detectionRules: List<DetectionRule>
 }
 

--- a/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/FixedPolicy.kt
+++ b/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/FixedPolicy.kt
@@ -15,5 +15,6 @@ data class FixedPolicy(
     val networkPolicy: NetworkPolicy,
     override val minimumVersionCode: Int,
     override val hasUnmodestImage: Boolean = false,
+    override val isPotentiallyDangerous: Boolean = false,
     override val detectionRules: List<DetectionRule> = emptyList()
 ) : AppPolicy

--- a/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/FixedPolicy.kt
+++ b/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/FixedPolicy.kt
@@ -14,5 +14,6 @@ data class FixedPolicy(
     override val category: AppCategory,
     val networkPolicy: NetworkPolicy,
     override val minimumVersionCode: Int,
+    override val hasUnmodestImage: Boolean = false,
     override val detectionRules: List<DetectionRule> = emptyList()
 ) : AppPolicy

--- a/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/ModeBasedPolicy.kt
+++ b/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/ModeBasedPolicy.kt
@@ -15,5 +15,6 @@ data class ModeBasedPolicy(
     override val category: AppCategory,
     val modePolicies: Map<UserMode, NetworkPolicy>,
     override val minimumVersionCode: Int,
+    override val hasUnmodestImage: Boolean = false,
     override val detectionRules: List<DetectionRule> = emptyList()
 ) : AppPolicy

--- a/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/ModeBasedPolicy.kt
+++ b/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/ModeBasedPolicy.kt
@@ -16,5 +16,6 @@ data class ModeBasedPolicy(
     val modePolicies: Map<UserMode, NetworkPolicy>,
     override val minimumVersionCode: Int,
     override val hasUnmodestImage: Boolean = false,
+    override val isPotentiallyDangerous: Boolean = false,
     override val detectionRules: List<DetectionRule> = emptyList()
 ) : AppPolicy

--- a/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/MultiModePolicy.kt
+++ b/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/MultiModePolicy.kt
@@ -40,6 +40,7 @@ data class MultiModePolicy(
     override val category: AppCategory,
     val modeVariants: List<ModeVariants>,
     override val minimumVersionCode: Int,
+    override val hasUnmodestImage: Boolean = false,
     override val detectionRules: List<DetectionRule> = emptyList()
 ) : AppPolicy {
 

--- a/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/MultiModePolicy.kt
+++ b/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/MultiModePolicy.kt
@@ -41,6 +41,7 @@ data class MultiModePolicy(
     val modeVariants: List<ModeVariants>,
     override val minimumVersionCode: Int,
     override val hasUnmodestImage: Boolean = false,
+    override val isPotentiallyDangerous: Boolean = false,
     override val detectionRules: List<DetectionRule> = emptyList()
 ) : AppPolicy {
 


### PR DESCRIPTION
### Description

This pull request introduces two new properties to the `AppPolicy` interface and its implementations: `hasUnmodestImage` and `isPotentiallyDangerous`. These properties enhance app filtering and classification by enabling the marking of policies with specific content or risk warnings.

Key updates include:
- **`hasUnmodestImage`**: A property to handle image-related policies, defaulting to `false`.
- **`isPotentiallyDangerous`**: A property to classify potentially risky app policies.

Both properties are implemented across `ModeBasedPolicy`, `MultiModePolicy`, and `FixedPolicy`. Examples demonstrating appropriate usage are also included.