### PR TITLE
com.apple.bnd.json

### DIFF
--- a/app-policies/music-audio/com.apple.bnd.json
+++ b/app-policies/music-audio/com.apple.bnd.json
@@ -1,0 +1,10 @@
+{
+  "type": "Fixed",
+  "packageName": "com.apple.bnd",
+  "category": "MUSIC_AUDIO",
+  "minimumVersionCode": 0,
+  "hasUnmodestImage": true,
+  "networkPolicy": {
+    "mode": "FULL_OPEN"
+  }
+}


### PR DESCRIPTION
beats (Apple's Bluetooth headphone app)
I put it in MUSIC_AUDIO, I think this is the place.
Contains a `hasUnmodestImage: true` flag due to women image in the user interface.
Thanks.