### PR TITLE
Add `requiresPlayStoreInstallation` functionality and update navigation modes

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -244,9 +244,11 @@ You can optionally include the following boolean flags in your policy files to h
 
 * **`isPotentiallyDangerous`**: Set to `true` if the app can pose a technical or security risk, such as remote access tools or apps capable of controlling other devices over open internet connections. This flag helps apply stricter rules or prompt additional warnings.
 
+* **`requiresPlayStoreInstallation`**: Set to `true` if the app must be installed from the Google Play Store for specific reasons (e.g., licensing requirements, app integrity verification, or access to Play Store-specific features). This indicates that the app should not be sideloaded from alternative sources.
+
 These fields are optional but enforced by default: apps with these flags will not appear in the store or be granted internet access unless the user has explicitly accepted the associated risk.
 
-Apps marked with either of these flags will only appear in the store or receive internet access **if the user has explicitly acknowledged the risk** and chosen to enable them manually.
+Apps marked with any of these flags will only appear in the store or receive internet access **if the user has explicitly acknowledged the risk** and chosen to enable them manually.
 
 ---
 
@@ -282,4 +284,19 @@ Apps marked with either of these flags will only appear in the store or receive 
 }
 ```
 
-Both of these apps are tagged for additional caution. They will only be functional or visible if the user has agreed to unlock them by accepting the risks.
+#### 3. App Requiring Play Store Installation
+
+```json
+{
+  "type": "Fixed",
+  "packageName": "com.example.licensedapp",
+  "category": "PRODUCTIVITY",
+  "minimumVersionCode": 75,
+  "requiresPlayStoreInstallation": true,
+  "networkPolicy": {
+    "mode": "FULL_OPEN"
+  }
+}
+```
+
+All of these apps are tagged for additional caution. They will only be functional or visible if the user has agreed to unlock them by accepting the risks.

--- a/README.MD
+++ b/README.MD
@@ -28,8 +28,8 @@ AppPolicy
 │   ├── "type": "ModeBased"
 │   ├── modePolicies
 │   │   ├── OFFLINE → NetworkPolicy{…}
-│   │   ├── GPS_ONLY → NetworkPolicy{…}
-│   │   ├── GPS_AND_MAIL → NetworkPolicy{…}
+│   │   ├── NAVIGATION_ONLY → NetworkPolicy{…}
+│   │   ├── NAVIGATION_AND_MAIL_ONLY → NetworkPolicy{…}
 │   │   ├── REDUCED_RISK → NetworkPolicy{…}
 │   │   └── MOST_OPEN → NetworkPolicy{…}
 │   └── detectionRules […]
@@ -109,7 +109,7 @@ Use when you need different rules per user mode.
   "category": "MAIL",
   "minimumVersionCode": 0,
   "modePolicies": {
-    "GPS_AND_MAIL": {
+    "NAVIGATION_AND_MAIL_ONLY": {
       "mode": "BLACKLIST",
       "desc": "Allow only mails and block Google Chat",
       "spec": {

--- a/README.MD
+++ b/README.MD
@@ -252,6 +252,24 @@ Apps marked with any of these flags will only appear in the store or receive int
 
 ---
 
+### Why would an app require Play Store installation?
+
+Some applications must be installed exclusively from the Google Play Store for several important reasons:
+
+1. **License Verification**: Many paid or subscription-based apps use Google Play's licensing services to verify purchases. When installed from alternative sources, these apps may not function properly as they cannot validate the purchase.
+
+2. **App Integrity & Security**: The Play Store provides app signing and verification mechanisms that help ensure the app hasn't been tampered with. Apps handling sensitive data (like banking or payment apps) often require this security layer.
+
+3. **Google Play Services Dependencies**: Some apps rely heavily on specific Google Play Services features that are only fully available for apps installed through official channels.
+
+4. **In-App Purchases**: Applications that offer in-app purchases typically use Google Play's billing system, which may not function correctly when the app is sideloaded.
+
+5. **Auto-Updates**: Apps installed from the Play Store can receive automatic updates, ensuring users always have the latest security patches and features.
+
+When you mark an app with `requiresPlayStoreInstallation: true`, you're indicating to users that the app should not be sideloaded from alternative sources, as this could lead to functionality issues, security risks, or licensing problems.
+
+---
+
 ### 🔄 Example: Risky Applications
 
 #### 1. Bank App with Inappropriate Visuals

--- a/app-policies/finance/com.ideomobile.hapoalim.json
+++ b/app-policies/finance/com.ideomobile.hapoalim.json
@@ -5,5 +5,6 @@
   "networkPolicy": {
     "mode": "FULL_OPEN"
   },
-  "minimumVersionCode": 0
+  "minimumVersionCode": 0,
+  "requiresPlayStoreInstallation": true
 }

--- a/app-policies/mail/com.google.android.gm.json
+++ b/app-policies/mail/com.google.android.gm.json
@@ -5,7 +5,7 @@
   "category": "MAIL",
   "minimumVersionCode": 0,
   "modePolicies": {
-    "GPS_AND_MAIL": {
+    "NAVIGATION_AND_MAIL_ONLY": {
       "mode": "BLACKLIST",
       "desc" : "Allow only mails and block google chat",
       "spec": {

--- a/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/UserMode.kt
+++ b/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/UserMode.kt
@@ -6,8 +6,8 @@ import kotlinx.serialization.Serializable
 enum class UserMode(val level: Int) {
     OFFLINE (level = 0),
     LOCAL_ONLY(level = 1),
-    GPS_ONLY(level = 2),
-    GPS_AND_MAIL(level = 3),
+    NAVIGATION_ONLY(level = 2),
+    NAVIGATION_AND_MAIL_ONLY(level = 3),
     REDUCED_RISK(level = 4),
     MOST_OPEN(level = 5)
 }

--- a/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/AppPolicy.kt
+++ b/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/AppPolicy.kt
@@ -10,8 +10,10 @@ sealed interface AppPolicy {
     val category: AppCategory
     val minimumVersionCode: Int
 
+    val requiresPlayStoreInstallation: Boolean
     val hasUnmodestImage : Boolean
     val isPotentiallyDangerous : Boolean
+
     val detectionRules: List<DetectionRule>
 }
 

--- a/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/FixedPolicy.kt
+++ b/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/FixedPolicy.kt
@@ -14,6 +14,7 @@ data class FixedPolicy(
     override val category: AppCategory,
     val networkPolicy: NetworkPolicy,
     override val minimumVersionCode: Int,
+    override val requiresPlayStoreInstallation: Boolean = false,
     override val hasUnmodestImage: Boolean = false,
     override val isPotentiallyDangerous: Boolean = false,
     override val detectionRules: List<DetectionRule> = emptyList()

--- a/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/ModeBasedPolicy.kt
+++ b/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/ModeBasedPolicy.kt
@@ -15,6 +15,7 @@ data class ModeBasedPolicy(
     override val category: AppCategory,
     val modePolicies: Map<UserMode, NetworkPolicy>,
     override val minimumVersionCode: Int,
+    override val requiresPlayStoreInstallation: Boolean = false,
     override val hasUnmodestImage: Boolean = false,
     override val isPotentiallyDangerous: Boolean = false,
     override val detectionRules: List<DetectionRule> = emptyList()

--- a/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/MultiModePolicy.kt
+++ b/core/src/commonMain/kotlin/io/github/kdroidfilter/database/core/policies/MultiModePolicy.kt
@@ -40,6 +40,7 @@ data class MultiModePolicy(
     override val category: AppCategory,
     val modeVariants: List<ModeVariants>,
     override val minimumVersionCode: Int,
+    override val requiresPlayStoreInstallation: Boolean = false,
     override val hasUnmodestImage: Boolean = false,
     override val isPotentiallyDangerous: Boolean = false,
     override val detectionRules: List<DetectionRule> = emptyList()


### PR DESCRIPTION
### Description

This pull request introduces the following changes:
- **Documentation Updates**:
  - Explained reasons for apps requiring installation via the Google Play Store in README. Reasons include licensing, security, dependency on Play Services, in-app purchases, and auto-updates.
  - Documented the new `requiresPlayStoreInstallation` flag in the README with clear examples and updated wording.
- **Functionality Enhancements**:
  - Added `requiresPlayStoreInstallation` property to policy models with a default value of `false` to enforce download restrictions.
  - Incorporated `requiresPlayStoreInstallation` into policy configuration for rigorous policy enforcement.
- **Naming Improvements**:
  - Renamed GPS-related modes: 
    - `GPS_ONLY` → `NAVIGATION_ONLY`
    - `GPS_AND_MAIL` → `NAVIGATION_AND_MAIL_ONLY`
  - Updated references in configuration files, enums, and documentation to reflect new terminology for better clarity and alignment.

---
### Checklist

- [x] Tests are written and cover all new changes
-