### PR TITLE
Add network DB loader for WASM

### DIFF
--- a/sample/composeApp/build.gradle.kts
+++ b/sample/composeApp/build.gradle.kts
@@ -15,10 +15,10 @@ kotlin {
 
     jvm()
     androidTarget()
-//    wasmJs {
-//        browser()
-//        binaries.executable()
-//    }
+    wasmJs {
+        browser()
+        binaries.executable()
+    }
 
     sourceSets {
         commonMain.dependencies {

--- a/sample/composeApp/src/androidMain/kotlin/sample/app/DatabaseManager.kt
+++ b/sample/composeApp/src/androidMain/kotlin/sample/app/DatabaseManager.kt
@@ -1,0 +1,84 @@
+package sample.app
+
+import co.touchlab.kermit.Logger
+import io.github.kdroidfilter.database.sample.Database
+import io.github.kdroidfilter.platformtools.releasefetcher.github.GitHubReleaseFetcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.URL
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+
+/**
+ * Android implementation of [DatabaseManager].
+ */
+actual object DatabaseManager {
+    private val logger = Logger.withTag("DatabaseManager")
+
+    actual suspend fun downloadLatestDatabaseIfNotExists(): Boolean {
+        val dbPath = Paths.get(getDatabasePath())
+
+        val dbFile = dbPath.toFile()
+        val dbExists = dbFile.exists() && dbFile.length() > 30000
+
+        if (dbExists) {
+            logger.i { "✅ Database already exists at $dbPath" }
+            return true
+        }
+
+        return refreshDatabase()
+    }
+
+    actual suspend fun refreshDatabase(): Boolean = withContext(Dispatchers.IO) {
+        try {
+            val dbPath = Paths.get(getDatabasePath())
+            logger.i { "🔄 Checking for database updates..." }
+
+            val fetcher = GitHubReleaseFetcher(owner = "kdroidFilter", repo = "KDroidDatabase")
+            val latestRelease = fetcher.getLatestRelease()
+
+            if (latestRelease != null && latestRelease.assets.size > 1) {
+                val dbFile = dbPath.toFile()
+                val dbExists = dbFile.exists() && dbFile.length() > 30000
+
+                if (dbExists) {
+                    try {
+                        val database = Database(createSqlDriver())
+                        val currentVersion = database.storeQueries.getCurrentVersion().executeAsOneOrNull()
+                        if (currentVersion != null && currentVersion.release_name == latestRelease.name) {
+                            logger.i { "✅ Database is already the most recent version (${latestRelease.name})" }
+                            return@withContext true
+                        }
+                    } catch (e: Exception) {
+                        logger.w(e) { "⚠️ Could not check current database version: ${'$'}{e.message}" }
+                    }
+                }
+
+                val downloadUrl = latestRelease.assets[1].browser_download_url
+
+                logger.i { "📥 Downloading database version ${'$'}{latestRelease.name} from: ${'$'}downloadUrl" }
+
+                Files.createDirectories(dbPath.parent)
+
+                URL(downloadUrl).openStream().use { input ->
+                    Files.copy(input, dbPath, StandardCopyOption.REPLACE_EXISTING)
+                }
+
+                if (dbFile.exists() && dbFile.length() > 30000) {
+                    logger.i { "✅ Database downloaded successfully to $dbPath" }
+                    return@withContext true
+                } else {
+                    logger.w { "⚠️ Downloaded file is empty, too small, or does not exist" }
+                    return@withContext false
+                }
+            } else {
+                logger.w { "⚠️ No database assets found in the latest release" }
+                return@withContext false
+            }
+        } catch (e: Exception) {
+            logger.e(e) { "❌ Failed to download the latest database: ${'$'}{e.message}" }
+            return@withContext false
+        }
+    }
+}

--- a/sample/composeApp/src/androidMain/kotlin/sample/app/SqlDriverFactory.kt
+++ b/sample/composeApp/src/androidMain/kotlin/sample/app/SqlDriverFactory.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import io.github.kdroidfilter.database.sample.Database
-import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.Locale
 import androidx.compose.ui.platform.LocalContext
@@ -26,9 +25,9 @@ actual fun createSqlDriver(): SqlDriver {
     return driver
 }
 
-actual fun getDatabasePath(): Path {
+actual fun getDatabasePath(): String {
     val databaseFile = applicationContext.getDatabasePath("store-database.db")
-    return Paths.get(databaseFile.absolutePath)
+    return Paths.get(databaseFile.absolutePath).toString()
 }
 
 actual fun getDeviceLanguage(): String {

--- a/sample/composeApp/src/commonMain/kotlin/sample/app/App.kt
+++ b/sample/composeApp/src/commonMain/kotlin/sample/app/App.kt
@@ -56,10 +56,9 @@ import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
-import java.nio.file.Path
 
 expect fun createSqlDriver(): SqlDriver
-expect fun getDatabasePath(): Path
+expect fun getDatabasePath(): String
 expect fun getDeviceLanguage(): String
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/sample/composeApp/src/commonMain/kotlin/sample/app/DatabaseManager.kt
+++ b/sample/composeApp/src/commonMain/kotlin/sample/app/DatabaseManager.kt
@@ -1,104 +1,18 @@
 package sample.app
 
-import app.cash.sqldelight.db.SqlDriver
-import co.touchlab.kermit.Logger
-import io.github.kdroidfilter.database.sample.Database
-import io.github.kdroidfilter.platformtools.releasefetcher.github.GitHubReleaseFetcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import java.net.URL
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.StandardCopyOption
-
 /**
- * Manages database operations, including downloading and refreshing the database.
+ * Manages database operations for platforms with a filesystem.
  */
-object DatabaseManager {
-    private val logger = Logger.withTag("DatabaseManager")
+expect object DatabaseManager {
+    /**
+     * Downloads the latest database if it does not exist locally.
+     * @return true if the database is available after the call, false otherwise.
+     */
+    suspend fun downloadLatestDatabaseIfNotExists(): Boolean
 
     /**
-     * Downloads the latest database from GitHub releases if it doesn't exist locally.
-     * @return true if download was successful or database already exists, false otherwise
+     * Refreshes the local database if a newer version is available.
+     * @return true if the database was refreshed, false otherwise.
      */
-    suspend fun downloadLatestDatabaseIfNotExists(): Boolean {
-        val dbPath = getDatabasePath()
-
-        // Check if database already exists and has data
-        val dbFile = dbPath.toFile()
-        val dbExists = dbFile.exists() && dbFile.length() > 30000
-
-        if (dbExists) {
-            logger.i { "✅ Database already exists at $dbPath" }
-            return true
-        }
-
-        // Database doesn't exist or is too small (likely empty), download it
-        return refreshDatabase()
-    }
-
-    /**
-     * Downloads the latest database from GitHub releases, replacing any existing database
-     * only if the current version is different from the latest release.
-     * @return true if download was successful or database is already up to date, false otherwise
-     */
-    suspend fun refreshDatabase(): Boolean = withContext(Dispatchers.IO) {
-        try {
-            val dbPath = getDatabasePath()
-            logger.i { "🔄 Checking for database updates..." }
-
-            val fetcher = GitHubReleaseFetcher(owner = "kdroidFilter", repo = "KDroidDatabase")
-            val latestRelease = fetcher.getLatestRelease()
-
-            if (latestRelease != null && latestRelease.assets.size > 1) {
-                // Check current database version
-                val dbFile = dbPath.toFile()
-                val dbExists = dbFile.exists() && dbFile.length() > 30000
-
-                if (dbExists) {
-                    try {
-                        // Create database instance to check version
-                        val database = Database(createSqlDriver())
-                        val currentVersion = database.storeQueries.getCurrentVersion().executeAsOneOrNull()
-
-                        // If current version matches latest release, no need to download
-                        if (currentVersion != null && currentVersion.release_name == latestRelease.name) {
-                            logger.i { "✅ Database is already the most recent version (${latestRelease.name})" }
-                            return@withContext true
-                        }
-                    } catch (e: Exception) {
-                        logger.w(e) { "⚠️ Could not check current database version: ${e.message}" }
-                        // Continue with download if we can't check the version
-                    }
-                }
-
-                // Find the store-database.db asset
-                val downloadUrl = latestRelease.assets[1].browser_download_url
-
-                logger.i { "📥 Downloading database version ${latestRelease.name} from: $downloadUrl" }
-
-                Files.createDirectories(dbPath.parent)
-
-                // Download the file
-                URL(downloadUrl).openStream().use { input ->
-                    Files.copy(input, dbPath, StandardCopyOption.REPLACE_EXISTING)
-                }
-
-                // Verify the file was downloaded successfully
-                if (dbFile.exists() && dbFile.length() > 30000) { // Ensure it's at least 30KB
-                    logger.i { "✅ Database downloaded successfully to $dbPath" }
-                    return@withContext true
-                } else {
-                    logger.w { "⚠️ Downloaded file is empty, too small, or does not exist" }
-                    return@withContext false
-                }
-            } else {
-                logger.w { "⚠️ No database assets found in the latest release" }
-                return@withContext false
-            }
-        } catch (e: Exception) {
-            logger.e(e) { "❌ Failed to download the latest database: ${e.message}" }
-            return@withContext false
-        }
-    }
+    suspend fun refreshDatabase(): Boolean
 }

--- a/sample/composeApp/src/jvmMain/kotlin/sample/app/DatabaseManager.kt
+++ b/sample/composeApp/src/jvmMain/kotlin/sample/app/DatabaseManager.kt
@@ -1,0 +1,84 @@
+package sample.app
+
+import co.touchlab.kermit.Logger
+import io.github.kdroidfilter.database.sample.Database
+import io.github.kdroidfilter.platformtools.releasefetcher.github.GitHubReleaseFetcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.URL
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+
+/**
+ * JVM implementation of [DatabaseManager].
+ */
+actual object DatabaseManager {
+    private val logger = Logger.withTag("DatabaseManager")
+
+    actual suspend fun downloadLatestDatabaseIfNotExists(): Boolean {
+        val dbPath = Paths.get(getDatabasePath())
+
+        val dbFile = dbPath.toFile()
+        val dbExists = dbFile.exists() && dbFile.length() > 30000
+
+        if (dbExists) {
+            logger.i { "✅ Database already exists at $dbPath" }
+            return true
+        }
+
+        return refreshDatabase()
+    }
+
+    actual suspend fun refreshDatabase(): Boolean = withContext(Dispatchers.IO) {
+        try {
+            val dbPath = Paths.get(getDatabasePath())
+            logger.i { "🔄 Checking for database updates..." }
+
+            val fetcher = GitHubReleaseFetcher(owner = "kdroidFilter", repo = "KDroidDatabase")
+            val latestRelease = fetcher.getLatestRelease()
+
+            if (latestRelease != null && latestRelease.assets.size > 1) {
+                val dbFile = dbPath.toFile()
+                val dbExists = dbFile.exists() && dbFile.length() > 30000
+
+                if (dbExists) {
+                    try {
+                        val database = Database(createSqlDriver())
+                        val currentVersion = database.storeQueries.getCurrentVersion().executeAsOneOrNull()
+                        if (currentVersion != null && currentVersion.release_name == latestRelease.name) {
+                            logger.i { "✅ Database is already the most recent version (${latestRelease.name})" }
+                            return@withContext true
+                        }
+                    } catch (e: Exception) {
+                        logger.w(e) { "⚠️ Could not check current database version: ${'$'}{e.message}" }
+                    }
+                }
+
+                val downloadUrl = latestRelease.assets[1].browser_download_url
+
+                logger.i { "📥 Downloading database version ${'$'}{latestRelease.name} from: ${'$'}downloadUrl" }
+
+                Files.createDirectories(dbPath.parent)
+
+                URL(downloadUrl).openStream().use { input ->
+                    Files.copy(input, dbPath, StandardCopyOption.REPLACE_EXISTING)
+                }
+
+                if (dbFile.exists() && dbFile.length() > 30000) {
+                    logger.i { "✅ Database downloaded successfully to $dbPath" }
+                    return@withContext true
+                } else {
+                    logger.w { "⚠️ Downloaded file is empty, too small, or does not exist" }
+                    return@withContext false
+                }
+            } else {
+                logger.w { "⚠️ No database assets found in the latest release" }
+                return@withContext false
+            }
+        } catch (e: Exception) {
+            logger.e(e) { "❌ Failed to download the latest database: ${'$'}{e.message}" }
+            return@withContext false
+        }
+    }
+}

--- a/sample/composeApp/src/jvmMain/kotlin/sample/app/SqlDriverFactory.kt
+++ b/sample/composeApp/src/jvmMain/kotlin/sample/app/SqlDriverFactory.kt
@@ -3,12 +3,11 @@ package sample.app
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import io.github.kdroidfilter.database.sample.Database
-import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.Locale
 
 actual fun createSqlDriver(): SqlDriver {
-    val dbPath = getDatabasePath()
+    val dbPath = Paths.get(getDatabasePath())
     val driver = JdbcSqliteDriver("jdbc:sqlite:${dbPath.toAbsolutePath()}")
 
     // Create tables if they don't exist
@@ -17,7 +16,7 @@ actual fun createSqlDriver(): SqlDriver {
     return driver
 }
 
-actual fun getDatabasePath(): Path {
+actual fun getDatabasePath(): String {
     // Use a path in the user's home directory
     val userHome = System.getProperty("user.home")
     val dbDir = Paths.get(userHome, ".kdroidfilter")
@@ -27,7 +26,7 @@ actual fun getDatabasePath(): Path {
         dbDir.toFile().mkdirs()
     }
 
-    return dbDir.resolve("store-database.db")
+    return dbDir.resolve("store-database.db").toString()
 }
 
 actual fun getDeviceLanguage(): String {

--- a/sample/composeApp/src/wasmJsMain/kotlin/sample/app/DatabaseManager.kt
+++ b/sample/composeApp/src/wasmJsMain/kotlin/sample/app/DatabaseManager.kt
@@ -1,0 +1,18 @@
+package sample.app
+
+/**
+ * WASM implementation of [DatabaseManager].
+ * WASM downloads the database from the network using the custom worker.
+ */
+actual object DatabaseManager {
+    actual suspend fun downloadLatestDatabaseIfNotExists(): Boolean {
+        // The WebWorker fetches the database on first access.
+        return true
+    }
+
+    actual suspend fun refreshDatabase(): Boolean {
+        // Reload the page to fetch the latest database.
+        js("location.reload()");
+        return true
+    }
+}

--- a/sample/composeApp/src/wasmJsMain/kotlin/sample/app/SqlDriverFactory.kt
+++ b/sample/composeApp/src/wasmJsMain/kotlin/sample/app/SqlDriverFactory.kt
@@ -1,0 +1,18 @@
+package sample.app
+
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.worker.WebWorkerDriver
+import org.w3c.dom.Worker
+
+actual fun createSqlDriver(): SqlDriver {
+    val worker = Worker(js("""new URL("sqljs.worker.js", import.meta.url)"""))
+    return WebWorkerDriver(worker)
+}
+
+actual fun getDatabasePath(): String {
+    error("File system is not available in WebAssembly")
+}
+
+actual fun getDeviceLanguage(): String {
+    return (js("navigator.language") as? String)?.substring(0,2) ?: "en"
+}

--- a/sample/composeApp/src/wasmJsMain/kotlin/sample/app/main.kt
+++ b/sample/composeApp/src/wasmJsMain/kotlin/sample/app/main.kt
@@ -1,0 +1,9 @@
+package sample.app
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.window.CanvasBasedWindow
+
+@OptIn(ExperimentalComposeUiApi::class)
+fun main() {
+    CanvasBasedWindow("KDroid Database") { App() }
+}

--- a/sample/composeApp/src/wasmJsMain/resources/sqljs.worker.js
+++ b/sample/composeApp/src/wasmJsMain/resources/sqljs.worker.js
@@ -1,0 +1,39 @@
+import initSqlJs from 'sql.js';
+
+let dbPromise;
+
+async function getDatabase() {
+  if (!dbPromise) {
+    const SQL = await initSqlJs({ locateFile: file => '/sql-wasm.wasm' });
+    const response = await fetch('https://github.com/kdroidFilter/KDroidDatabase/releases/latest/download/store-database.db');
+    const buffer = await response.arrayBuffer();
+    dbPromise = new SQL.Database(new Uint8Array(buffer));
+  }
+  return dbPromise;
+}
+
+self.onmessage = async (event) => {
+  const data = event.data;
+  try {
+    const db = await getDatabase();
+    switch (data && data.action) {
+      case 'exec':
+        if (!data['sql']) throw new Error('exec: Missing query string');
+        postMessage({ id: data.id, results: db.exec(data.sql, data.params)[0] ?? { values: [] } });
+        break;
+      case 'begin_transaction':
+        postMessage({ id: data.id, results: db.exec('BEGIN TRANSACTION;') });
+        break;
+      case 'end_transaction':
+        postMessage({ id: data.id, results: db.exec('END TRANSACTION;') });
+        break;
+      case 'rollback_transaction':
+        postMessage({ id: data.id, results: db.exec('ROLLBACK TRANSACTION;') });
+        break;
+      default:
+        throw new Error(`Unsupported action: ${data && data.action}`);
+    }
+  } catch (err) {
+    postMessage({ id: data.id, error: err });
+  }
+};

--- a/sample/composeApp/webpack.config.d/sqljs.js
+++ b/sample/composeApp/webpack.config.d/sqljs.js
@@ -1,0 +1,16 @@
+config.resolve = {
+    fallback: {
+        fs: false,
+        path: false,
+        crypto: false,
+    }
+};
+
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+config.plugins.push(
+    new CopyWebpackPlugin({
+        patterns: [
+            '../../node_modules/sql.js/dist/sql-wasm.wasm'
+        ]
+    })
+);


### PR DESCRIPTION
## Summary
- add a custom SQL.js worker that fetches the database from GitHub
- load the new worker in the WASM driver factory
- update the WASM DatabaseManager to indicate the database is downloaded

## Testing
- `./gradlew -q help`


------
https://chatgpt.com/codex/tasks/task_e_684845143cd88331a4c1169a94953121