### PR TITLE
Update `SqliteStoreBuilder` to insert version for downloaded databases

### DIFF
--- a/generators/store/src/jvmMain/kotlin/SqliteStoreBuilder.kt
+++ b/generators/store/src/jvmMain/kotlin/SqliteStoreBuilder.kt
@@ -383,6 +383,14 @@ object SqliteStoreBuilder {
 
             if (downloadResults[language] == true) {
                 logger.i { "📄 Using downloaded database for $language, updating with new packages only..." }
+                // Get release name from environment variable or generate timestamp
+                val releaseName = System.getenv("RELEASE_NAME") ?: LocalDateTime.now()
+                    .format(DateTimeFormatter.ofPattern("yyyyMMddHHmm"))
+                logger.i { "🏷️ Updating version to: $releaseName for language: $language" }
+
+                // Update version even for downloaded databases
+                insertVersion(releaseName, dbPath)
+
                 // Update the downloaded database with only new packages
                 updatePackagesIfNotExists(appPoliciesDir, dbPath, language, country)
             } else {


### PR DESCRIPTION
- Added logic to derive `releaseName` from an environment variable or timestamp.
- Ensured the version is updated even for previously downloaded databases.