### PR TITLE
add app com.zeitech.remote.json

### DIFF
--- a/app-policies/tools/com.zeitech.remote.json
+++ b/app-policies/tools/com.zeitech.remote.json
@@ -1,0 +1,15 @@
+{
+    "type": "Fixed",
+    "packageName": "com.zeitech.remote",
+    "category": "TOOLS",
+    "networkPolicy": {
+        "mode": "WHITELIST",
+        "spec": {
+            "type": "HostList",
+            "hosts": [
+                "r.zeitech.co.il"
+            ]
+        }
+    },
+    "minimumVersionCode": 0
+}


### PR DESCRIPTION
Commercial smart home system, I think it's a webview, so networkpolicy: whitelist
I strongly believe "r.zeitech.co.il" is the necessary host - I sent an email to Zeitech's service, and when they respond, I will update if needed.
